### PR TITLE
Add TWZRD Agent Intel — Solana x402 trust receipt MCP plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@ In Cowork, plugins appear in the workspace's plugin manager — connect the mark
 
 - [RevenueCat](https://www.revenuecat.com) - Manage RevenueCat in-app purchase backend directly from your development workflow. *Use case: Subscription product configuration, entitlement management, IAP backend tuning.* (Claude Code)
 - [Stripe](https://stripe.com) - Development plugin for payments, billing, subscriptions, and Stripe API integration. *Use case: Stripe API exploration, payment-flow development, subscription-product configuration.* (Claude Code)
+- **[TWZRD Agent Intel](https://github.com/twzrd-sol/wzrd-final)** — Solana-native AI agent trust scoring + x402 payment receipt MCP plugin. Issues signed V5 trust receipts via HTTP 402 micropayment protocol. Free preflight scoring, paid receipts at https://intel.twzrd.xyz/mcp. *Use case: Agent trust verification, x402 payment receipts, on-chain Solana trust scoring.* (Claude Code)
 
 
 ## Platforms and SaaS


### PR DESCRIPTION
## Summary

- Adds **TWZRD Agent Intel** to the Payments and Billing section
- Solana-native AI agent trust scoring + x402 payment receipt MCP plugin
- Complements existing Stripe/RevenueCat entries with Web3/on-chain payment receipts

## Details

TWZRD Agent Intel is a production-live MCP plugin for Claude Code covering the emerging agent-to-agent payment trust layer:

- **Free preflight scoring**: Query on-chain Solana trust history before transacting
- **Paid V5 trust receipts**: Cryptographically signed receipts issued via HTTP 402 (x402 protocol)
- **Streamable-HTTP**: Compatible with Claude Code's `.mcp.json` configuration

The x402 protocol (now governed by the Linux Foundation) is the emerging standard for AI agent micropayments. TWZRD is the Solana-native implementation adding on-chain trust scoring on top.

Source: https://github.com/twzrd-sol/wzrd-final  
MCP endpoint: https://intel.twzrd.xyz/mcp

🤖 Generated with [Claude Code](https://claude.com/claude-code)