### PR TITLE
feat: add NotFair to Plugin Marketplaces (SEO, Google Ads & Meta Ads skills)

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,7 +503,7 @@ A plugin marketplace is a git repo or URL hosting `.claude-plugin/marketplace.js
 
 - [claude-plugins-official](https://github.com/anthropics/claude-plugins-public#readme) - Anthropic's curated, vetted marketplace, auto-installed on Claude Code startup. *Use case: First-stop discovery; install with `/plugin install <name>@claude-plugins-official`.*
 - [claude-code-plugins (Anthropic demo)](https://github.com/anthropics/claude-code) - Anthropic's example marketplace of reference plugins demonstrating the plugin system. *Use case: Plugin format examples, integration patterns; install with `/plugin marketplace add anthropics/claude-code`.*
-- [NotFair](https://github.com/nowork-studio/NotFair) - Open-source SEO, GEO, Google Ads, and Meta Ads skills for Claude Code, connecting to live data via Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP. *Install with `/plugin marketplace add nowork-studio/NotFair`.*
+- [NotFair](https://github.com/nowork-studio/NotFair) - Open-source SEO, GEO, Google Ads, and Meta Ads skills for Claude Code (18 skills, MIT). *Install with `/plugin marketplace add nowork-studio/NotFair`.*
 - [Seth Hobson's sub-agents](https://github.com/wshobson/agents) - 80+ specialized sub-agents packaged as a plugin collection.
 - [ClaudePluginHub](https://www.claudepluginhub.com) - Community-maintained third-party plugin discovery hub indexing marketplaces and individual plugins outside the official directory.
 

--- a/README.md
+++ b/README.md
@@ -503,6 +503,7 @@ A plugin marketplace is a git repo or URL hosting `.claude-plugin/marketplace.js
 
 - [claude-plugins-official](https://github.com/anthropics/claude-plugins-public#readme) - Anthropic's curated, vetted marketplace, auto-installed on Claude Code startup. *Use case: First-stop discovery; install with `/plugin install <name>@claude-plugins-official`.*
 - [claude-code-plugins (Anthropic demo)](https://github.com/anthropics/claude-code) - Anthropic's example marketplace of reference plugins demonstrating the plugin system. *Use case: Plugin format examples, integration patterns; install with `/plugin marketplace add anthropics/claude-code`.*
+- [NotFair](https://github.com/nowork-studio/NotFair) - Open-source SEO, GEO, Google Ads, and Meta Ads skills for Claude Code, connecting to live data via Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP. *Install with `/plugin marketplace add nowork-studio/NotFair`.*
 - [Seth Hobson's sub-agents](https://github.com/wshobson/agents) - 80+ specialized sub-agents packaged as a plugin collection.
 - [ClaudePluginHub](https://www.claudepluginhub.com) - Community-maintained third-party plugin discovery hub indexing marketplaces and individual plugins outside the official directory.
 


### PR DESCRIPTION
Thanks for maintaining this list — it's a genuinely useful reference.

I'd like to add **[NotFair](https://github.com/nowork-studio/NotFair)**, an open-source Claude Code plugin (~2.9k stars, MIT) focused on marketing workflows: SEO/GEO analysis, Google Ads management, and Meta Ads management. It ships with a `.claude-plugin/marketplace.json`, so it installs via `/plugin marketplace add nowork-studio/NotFair` — which is why I'm adding it to the Plugin Marketplaces section rather than the main categorized list.

It connects to live account data through the Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP, giving Claude Code agents direct access to campaign and site performance data.

Happy to reword, move it, or trim the description if needed. Thanks again for the list!